### PR TITLE
Change package option default to use our own output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
     });
 
     nixosModules = {
-      default = import ./modules/meshtastic.nix;
+      default = import ./modules/meshtastic.nix self;
 
       # Tries to automagically configure SPI and I2C on Raspberry Pi
       # with `config.txt`

--- a/modules/meshtastic.nix
+++ b/modules/meshtastic.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ...}:
+self: { config, lib, pkgs, ...}:
 
 with lib;
 
@@ -14,7 +14,7 @@ in {
   options.services.meshtastic = {
     enable = mkEnableOption "Meshtastic native daemon";
 
-    package = mkPackageOption pkgs "meshtasticd" {};
+    package = mkPackageOption self.packages.${pkgs.system} "meshtasticd" {};
 
     user = mkOption {
       type = types.str;


### PR DESCRIPTION
I basically have no idea what I'm doing when it comes to Nix, and especially flakes, but after mashing keys for a few hours this PR seems to be what is required to avoid having to manually set `services.meshtastic.package` from the calling system configuration flake? I'm using deploy-rs which may have altered the behaviour slightly, but without this I couldn't avoid having to do:
```
  services.meshtastic = {
    enable = true;
    package = inputs.meshtastic.packages."${pkgs.system}".meshtasticd;
  };
```