### PR TITLE
Set meshtastic service working directory to data dir

### DIFF
--- a/modules/meshtastic.nix
+++ b/modules/meshtastic.nix
@@ -145,6 +145,7 @@ in {
           User = cfg.user;
           Group = cfg.group;
           UMask = "0077";
+          WorkingDirectory = cfg.dataDir;
           ExecStart = lib.concatStringsSep " " [
             "${cfg.package}/bin/meshtasticd"
             "--config=${configFile}"


### PR DESCRIPTION
Self-signed certs for HTTPS seem to get saved in whatever meshtasticd's current working directory is, so setting that to the configured data directory seems reasonable?